### PR TITLE
Relaunch v2.0.0 to remove the proxy

### DIFF
--- a/demo/notebook/vertex_ai_demo_product_returns_case_study.ipynb
+++ b/demo/notebook/vertex_ai_demo_product_returns_case_study.ipynb
@@ -429,7 +429,8 @@
     "gcloud auth configure-docker $GCP_REGION-docker.pkg.dev\n",
     "gcloud storage buckets create gs://$GCP_BUCKET_NAME\n",
     "gsutil iam ch serviceAccount:$GCP_PROJECT_NUMBER-compute@developer.gserviceaccount.com:roles/storage.objectAdmin gs://$GCP_BUCKET_NAME\n",
-    "gcloud projects add-iam-policy-binding $GCP_PROJECT_ID --member=serviceAccount:$GCP_PROJECT_NUMBER-compute@developer.gserviceaccount.com --role=roles/aiplatform.user"
+    "gcloud projects add-iam-policy-binding $GCP_PROJECT_ID --member=serviceAccount:$GCP_PROJECT_NUMBER-compute@developer.gserviceaccount.com --role=roles/aiplatform.user\n",
+    "gcloud projects add-iam-policy-binding $GCP_PROJECT_ID --member=serviceAccount:$GCP_PROJECT_NUMBER-compute@developer.gserviceaccount.com --role=roles/artifactregistry.reader"
    ]
   },
   {


### PR DESCRIPTION
Now that the [getGoogleAuth](https://developers.google.com/tag-platform/tag-manager/server-side/api#getgoogleauth) API has fully launched, we can remove the proxy and launch v2.0.0.